### PR TITLE
escape `@` for uikit scss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 [UNRELEASED]
 
+[0.1.7]
+
+- update rust_generator escapeClassName to include `@`
+
 [0.1.6]
 
 - Updated dependencies

--- a/generators/rust_generator.js
+++ b/generators/rust_generator.js
@@ -69,6 +69,7 @@ function escapeClassName (name) {
   name = name.replace(/-/g, '_')
   name = name.replace(/:/g, '__')
   name = name.replace(/\//g, 'of')
+  name = name.replace(/@/g, '_at_')
   if (getKeywords().indexOf(name) > -1) {
     name += '_'
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-typed-css-classes",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "PostCSS plugin that generates typed entities from CSS classes for chosen programming language.",
   "keywords": [
     "postcss",


### PR DESCRIPTION
Fixes parse error when parsing `@` UIkit SCSS